### PR TITLE
Update README.md - fix coveralls badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 `develop`
 
 [![Build Status](https://travis-ci.com/gcivil-nyu-org/spring2020-cs-gy-9223-frontend.svg?branch=develop)](https://travis-ci.com/gcivil-nyu-org/spring2020-cs-gy-9223-frontend.svg?branch=develop)
-[![Coverage Status](https://coveralls.io/repos/github/gcivil-nyu-org/spring2020-cs-gy-9223-frontend/badge.svg?branch=develop)](https://coveralls.io/github/gcivil-nyu-org/spring2020-cs-gy-9223-frontend?branch=develop)
+[![Coverage Status](https://coveralls.io/repos/github/gcivil-nyu-org/spring2020-cs-gy-9223-frontend/badge.svg?branch=develop)](https://coveralls.io/github/gcivil-nyu-org/spring2020-cs-gy-9223-frontend?branch=develop&service=github)
 
 `master`
 
 [![Build Status](https://travis-ci.com/gcivil-nyu-org/spring2020-cs-gy-9223-frontend.svg?branch=master)](https://travis-ci.com/gcivil-nyu-org/spring2020-cs-gy-9223-frontend.svg?branch=master)
-[![Coverage Status](https://coveralls.io/repos/github/gcivil-nyu-org/spring2020-cs-gy-9223-frontend/badge.svg?branch=master)](https://coveralls.io/github/gcivil-nyu-org/spring2020-cs-gy-9223-frontend?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/gcivil-nyu-org/spring2020-cs-gy-9223-frontend/badge.svg?branch=master)](https://coveralls.io/github/gcivil-nyu-org/spring2020-cs-gy-9223-frontend?branch=master&service=github)
 
 # Team Project repo
 


### PR DESCRIPTION
Adding `&service=github` to the end of the coveralls badges allows them to stay up to date. [Others have had the issue](https://github.com/lemurheavy/coveralls-public/issues/971)